### PR TITLE
Fix deprecation of editor class and change shortcut

### DIFF
--- a/keymaps/open-in-browser.cson
+++ b/keymaps/open-in-browser.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
-  'ctrl-alt-m': 'open-in-browser:open'
+'atom-text-editor':
+  'ctrl-alt-q': 'open-in-browser:open'


### PR DESCRIPTION
Replace editor class with atom-text-editor tag.
Shortcut was conflicting with meteor developers who use Ctrl-Alt-M in
Meteor.js packages for Atom, so use Ctrl-Alt-Q instead.