### PR TITLE
Code review

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,0 +1,1 @@
+spec/fixtures/

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+git:
+  depth: 10
+
+branches:
+  only:
+    - master
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 <Your name here>
+Copyright (c) 2014 <magbicaleman>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ Now able to right click on tree-view and select "Open in browser"
 
 Update by "mesosteros"
 
-Replace editor class with atom-text-editor tag.
-Shortcut was conflicting with meteor developers who use Ctrl-Alt-M in
-Meteor.js packages for Atom, so use Ctrl-Alt-Q instead.
+Replace editor class with `atom-text-editor` tag.
+Shortcut was conflicting with meteor developers who use <kbd>Ctrl-Alt-M</kbd> in
+Meteor.js packages for Atom, so use <kbd>Ctrl-Alt-Q</kbd> instead.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-Open in Browser Atom.io Package
-===============================
+# Open in Browser Atom.io Package
+
+[![Atom Package](https://img.shields.io/apm/v/open-in-browser.svg)](https://atom.io/packages/open-in-browser)
+[![Atom Package Downloads](https://img.shields.io/apm/dm/open-in-browser.svg)](https://atom.io/packages/open-in-browser)
+[![Build Status (Linux)](https://travis-ci.org/magbicaleman/open-in-browser.svg?branch=master)](https://travis-ci.org/magbicaleman/open-in-browser)
+<!-- [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/XXXXXXXXX?svg=true)](https://ci.appveyor.com/project/magbicaleman/open-in-browser) -->
+[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/magbicaleman/open-in-browser/blob/master/LICENSE.md)
 
 A very simple Open in Browser Atom.io Package. This allows you to right click
 and have a menu that will open the current file in your default program. That

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: '{build}'
+
+skip_tags: true
+
+clone_depth: 10
+
+platform: x64
+
+environment:
+  APM_TEST_PACKAGES:
+  matrix:
+    - ATOM_CHANNEL: stable
+    - ATOM_CHANNEL: beta
+
+install:
+  - ps: Install-Product node 5
+
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+test: off
+
+deploy: off

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,37 @@
+{
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error"
+  },
+  "prefer_english_operator": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "spacing": {
+      "left": 0,
+      "right": 1
+    },
+    "level": "error"
+  },
+  "braces_spacing": {
+    "spaces": 0,
+    "level": "error"
+  },
+  "spacing_after_comma": {
+    "level": "error"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  }
+}

--- a/keymaps/open-in-browser.cson
+++ b/keymaps/open-in-browser.cson
@@ -1,11 +1,8 @@
-# Keybindings require three things to be fully defined: A selector that is
-# matched against the focused element, the keystroke and the command to
-# execute.
-#
-# Below is a basic keybinding which registers on all platforms by applying to
-# the root workspace element.
+'.platform-win32 atom-workspace atom-text-editor':
+  'ctrl-shift-q': 'open-in-browser:open'
 
-# For more detailed documentation see
-# https://atom.io/docs/latest/advanced/keymaps
-'atom-text-editor':
-  'ctrl-alt-q': 'open-in-browser:open'
+'.platform-linux atom-workspace atom-text-editor':
+  'ctrl-shift-q': 'open-in-browser:open'
+
+'.platform-darwin atom-workspace atom-text-editor':
+  'cmd-shift-q': 'open-in-browser:open'

--- a/lib/open-in-browser.coffee
+++ b/lib/open-in-browser.coffee
@@ -1,6 +1,5 @@
 {CompositeDisposable} = require 'atom'
-{exec} = require('child_process')
-Shell = require('shell')
+opn = require 'opn'
 
 module.exports =
 
@@ -13,20 +12,9 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-panel', 'open-in-browser:open-tree-view': => @openTreeView()
 
   openPath: (filePath) ->
-    switch process.platform
-      when 'darwin' then exec "open '#{filePath}'", (error, stdout, stderr) ->
-        if (error)
-          atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
-          console.error error
-          return
-        console.log "stderr: #{stderr}" if stderr
-      when 'linux' then exec "xdg-open '#{filePath}'", (error, stdout, stderr) ->
-        if (error)
-          atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
-          console.error error
-          return
-        console.log "stderr: #{stderr}" if stderr
-      when 'win32' then Shell.openExternal "file:///#{filePath}"
+    opn(filePath).catch (error) ->
+      atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
+      console.error error
 
   open: ->
     editor = atom.workspace.getActivePaneItem()

--- a/lib/open-in-browser.coffee
+++ b/lib/open-in-browser.coffee
@@ -1,19 +1,32 @@
+{CompositeDisposable} = require 'atom'
 {exec} = require('child_process')
-
 Shell = require('shell')
 
 module.exports =
 
-  activate: (state) ->
-    atom.commands.add 'atom-text-editor', 'open-in-browser:open': => @open()
-    atom.commands.add 'atom-panel', 'open-in-browser:open-tree-view' : => @openTreeView()
+  subscriptions: null
+
+  activate: ->
+    @subscriptions = new CompositeDisposable
+
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'open-in-browser:open': => @open()
+    @subscriptions.add atom.commands.add 'atom-panel', 'open-in-browser:open-tree-view': => @openTreeView()
 
   openPath: (filePath) ->
-    process_architecture = process.platform
-    switch process_architecture
-      when 'darwin' then exec ('open "'+filePath+'"')
-      when 'linux' then exec ('xdg-open "'+filePath+'"')
-      when 'win32' then Shell.openExternal('file:///'+filePath)
+    switch process.platform
+      when 'darwin' then exec "open '#{filePath}'", (error, stdout, stderr) ->
+        if (error)
+          atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
+          console.error error
+          return
+        console.log "stderr: #{stderr}" if stderr
+      when 'linux' then exec "xdg-open '#{filePath}'", (error, stdout, stderr) ->
+        if (error)
+          atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
+          console.error error
+          return
+        console.log "stderr: #{stderr}" if stderr
+      when 'win32' then Shell.openExternal "file:///#{filePath}"
 
   open: ->
     editor = atom.workspace.getActivePaneItem()
@@ -22,15 +35,20 @@ module.exports =
     @openPath filePath
 
   openTreeView: ->
-    packageObj = null
-    if atom.packages.isPackageLoaded('nuclide-file-tree') == true
-      nuclideFileTree = atom.packages.getLoadedPackage('nuclide-file-tree')
-      path = nuclideFileTree.contextMenuManager.activeElement?.getAttribute('data-path')
-      packageObj = selectedPath:path
-    if atom.packages.isPackageLoaded('tree-view') == true
-      treeView = atom.packages.getLoadedPackage('tree-view')
-      treeView = require(treeView.mainModulePath)
-      packageObj = treeView.serialize()
-    if typeof packageObj != 'undefined' && packageObj != null
-      if packageObj.selectedPath
-        @openPath packageObj.selectedPath
+    selectedPath = null
+
+    if atom.packages.isPackageLoaded 'nuclide-file-tree'
+      nuclideFileTree = atom.packages.getLoadedPackage 'nuclide-file-tree'
+      path = nuclideFileTree.contextMenuManager.activeElement?.getAttribute 'data-path'
+      selectedPath = path
+
+    else if atom.packages.isPackageLoaded 'tree-view'
+      treeView = atom.packages.getLoadedPackage 'tree-view'
+      mainModulePath = require treeView.mainModulePath
+      packageObj = mainModulePath.serialize()
+      selectedPath = packageObj?.selectedPath
+
+    @openPath selectedPath if selectedPath
+
+  deactivate: ->
+    @subscriptions?.dispose()

--- a/lib/open-in-browser.coffee
+++ b/lib/open-in-browser.coffee
@@ -8,16 +8,16 @@ module.exports =
   activate: ->
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'open-in-browser:open', @open.bind(this)
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'open-in-browser:open', @openEditor.bind(this)
     @subscriptions.add atom.commands.add '.tree-view .file', 'open-in-browser:open-tree-view', @openTreeView.bind(this)
 
-  open: ({target}) ->
-    @openPath target.getModel().getPath()
+  openEditor: ({target}) ->
+    @open target.getModel().getPath()
 
   openTreeView: ({target}) ->
-    @openPath target.dataset.path
+    @open target.dataset.path
 
-  openPath: (filePath) ->
+  open: (filePath) ->
     opn(filePath).catch (error) ->
       atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
       console.error error

--- a/lib/open-in-browser.coffee
+++ b/lib/open-in-browser.coffee
@@ -8,35 +8,19 @@ module.exports =
   activate: ->
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'open-in-browser:open': => @open()
-    @subscriptions.add atom.commands.add 'atom-panel', 'open-in-browser:open-tree-view': => @openTreeView()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'open-in-browser:open', @open.bind(this)
+    @subscriptions.add atom.commands.add '.tree-view .file', 'open-in-browser:open-tree-view', @openTreeView.bind(this)
+
+  open: ({target}) ->
+    @openPath target.getModel().getPath()
+
+  openTreeView: ({target}) ->
+    @openPath target.dataset.path
 
   openPath: (filePath) ->
     opn(filePath).catch (error) ->
       atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
       console.error error
-
-  open: ->
-    editor = atom.workspace.getActivePaneItem()
-    file = editor?.buffer.file
-    filePath = file?.path
-    @openPath filePath
-
-  openTreeView: ->
-    selectedPath = null
-
-    if atom.packages.isPackageLoaded 'nuclide-file-tree'
-      nuclideFileTree = atom.packages.getLoadedPackage 'nuclide-file-tree'
-      path = nuclideFileTree.contextMenuManager.activeElement?.getAttribute 'data-path'
-      selectedPath = path
-
-    else if atom.packages.isPackageLoaded 'tree-view'
-      treeView = atom.packages.getLoadedPackage 'tree-view'
-      mainModulePath = require treeView.mainModulePath
-      packageObj = mainModulePath.serialize()
-      selectedPath = packageObj?.selectedPath
-
-    @openPath selectedPath if selectedPath
 
   deactivate: ->
     @subscriptions?.dispose()

--- a/menus/open-in-browser.cson
+++ b/menus/open-in-browser.cson
@@ -1,17 +1,19 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 
 'context-menu':
-  'atom-text-editor': [{label: 'Open in Browser', command: 'open-in-browser:open'}]
-  '.tree-view .file' : [{label: 'Open in Browser', command: 'open-in-browser:open-tree-view'}]
+  'atom-text-editor': [
+    label: 'Open in Browser', command: 'open-in-browser:open'
+  ]
+  '.tree-view .file': [
+    label: 'Open in Browser', command: 'open-in-browser:open-tree-view'
+  ]
 
-'menu': [
-  {
-    'label': 'Packages'
-    'submenu': [
-      'label': 'Open in Browser'
-      'submenu': [
-        { 'label': 'Open In Browser', 'command': 'open-in-browser:open' }
-      ]
+menu: [
+  label: 'Packages'
+  submenu: [
+    label: 'Open in Browser'
+    submenu: [
+      label: 'Open In Browser', command: 'open-in-browser:open'
     ]
-  }
+  ]
 ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-in-browser",
   "main": "./lib/open-in-browser",
   "version": "0.4.7",
-  "description": "Simple Package to open file in default Browser",
+  "description": "Simple Package to open file in default application",
   "repository": "https://github.com/magbicaleman/open-in-browser",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "main": "./lib/open-in-browser",
   "version": "0.4.7",
   "description": "Simple Package to open file in default Browser",
+  "repository": "https://github.com/magbicaleman/open-in-browser",
+  "license": "MIT",
+  "engines": {
+    "atom": ">0.50.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "coffeelint": "^1.15.0"
+  },
   "activationCommands": {
     "atom-text-editor": [
       "open-in-browser:open"
@@ -10,11 +19,5 @@
     "atom-panel": [
       "open-in-browser:open-tree-view"
     ]
-  },
-  "repository": "https://github.com/magbicaleman/open-in-browser",
-  "license": "MIT",
-  "engines": {
-    "atom": ">0.50.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "opn": "^4.0.2"
+  },
   "devDependencies": {
     "coffeelint": "^1.15.0"
   },

--- a/spec/open-in-browser-spec.coffee
+++ b/spec/open-in-browser-spec.coffee
@@ -1,0 +1,10 @@
+describe 'Open in browser preview', ->
+  pack = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'open-in-browser'
+        .then (p) -> pack = p
+
+  it 'should load the package', ->
+    expect(pack.name).toBe 'open-in-browser'

--- a/styles/open-in-browser.less
+++ b/styles/open-in-browser.less
@@ -1,8 +1,0 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
-// for a full listing of what's available.
-@import "ui-variables";
-
-.open-in-browser {
-}


### PR DESCRIPTION
- use Disposables
- use notification for errors
- add CI configurations (you must activate CI in [Travis CI](https://travis-ci.org) and [AppVeyor](https://ci.appveyor.com))
- add CoffeeLint configuration
- use Opn (don't reinvent the wheel)
- works with standard Atom and Nuclide
- fix keymaps bindings and change to <kbd>ctrl-shift-q</kbd> and <kbd>cmd-shift-q</kbd> on OSX

Fix #28, #26, #25, #23, #21
