### PR TITLE
Modifies Mac/Linux Keyboard Shortcut

### DIFF
--- a/keymaps/open-in-browser.cson
+++ b/keymaps/open-in-browser.cson
@@ -5,4 +5,4 @@
   'ctrl-shift-q': 'open-in-browser:open'
 
 '.platform-darwin atom-workspace atom-text-editor':
-  'cmd-shift-q': 'open-in-browser:open'
+  'cmd-alt-b': 'open-in-browser:open'


### PR DESCRIPTION
The current shortcut on MacOS causes the Logout system dialog to start. The shortcut would now be  command + option + b (as in browser).