### PR TITLE
Issue 47

### DIFF
--- a/lib/open-in-browser.coffee
+++ b/lib/open-in-browser.coffee
@@ -21,7 +21,8 @@ module.exports =
 
   openEditor: ->
     @getFilePath()
-      .then (result) => @open result
+      .then (result) =>
+        if result? then @open result else Error 'Path undefined for editor content. (Has it been saved?)'
       .catch (error) => @report error
 
   openTreeView: ({target}) ->

--- a/lib/open-in-browser.coffee
+++ b/lib/open-in-browser.coffee
@@ -12,18 +12,27 @@ module.exports =
     @subscriptions.add atom.commands.add '.tree-view .file',
       'open-in-browser:open-tree-view', @openTreeView.bind(this)
 
-  getFilePath: -> atom.workspace.getActiveTextEditor().getPath()
+  getFilePath: ->
+    new Promise (resolve, reject) ->
+      if atom.workspace.hasActiveTextEditor
+        resolve atom.workspace.getActiveTextEditor().getPath()
+      else
+        reject Error 'Active pane item is not a text editor.'
 
   openEditor: ->
-    @open @getFilePath()
+    @getFilePath()
+      .then (result) => @open result
+      .catch (error) => @report error
 
   openTreeView: ({target}) ->
     @open target.dataset.path
 
   open: (filePath) ->
-    opn(filePath).catch (error) ->
-      atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
-      console.error error
+    opn(filePath)
+
+  report: (error) ->
+    atom.notifications.addError error.toString(), detail: error.stack or '', dismissable: true
+    console.error error
 
   deactivate: ->
     @subscriptions?.dispose()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-in-browser",
   "main": "./lib/open-in-browser",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Simple Package to open file in default application",
   "repository": "https://github.com/magbicaleman/open-in-browser",
   "license": "MIT",


### PR DESCRIPTION
This adds a sanity-check for circumstances where [Workspace.getActiveTextEditor()](https://atom.io/docs/api/v1.34.0/Workspace#instance-getActiveTextEditor) or [TextEditor.getPath()](https://atom.io/docs/api/v1.34.0/TextEditor#instance-getPath)  returns `'undefined'`. It also changes the flow of control to prevent exceptions from propagating up the call stack.
